### PR TITLE
Update README for the Windows path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Older models (even those with tool use specified) may not work and may throw a "
 
 **Example paths:**
 - macOS/Linux: `~/mcp-servers/web-search-mcp/dist/index.js`
-- Windows: `C:\\mcp-servers\web-search-mcp\dist\index.js`
+- Windows: `C:\\mcp-servers\\web-search-mcp\\dist\\index.js`
 
 **Note:** You must run `npm install` in the root of the extracted folder (not in `dist/`).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Older models (even those with tool use specified) may not work and may throw a "
 
 **Example paths:**
 - macOS/Linux: `~/mcp-servers/web-search-mcp/dist/index.js`
-- Windows: `C:/mcp-servers/web-search-mcp/dist/index.js`
+- Windows: `C:\\mcp-servers\web-search-mcp\dist\index.js`
 
 **Note:** You must run `npm install` in the root of the extracted folder (not in `dist/`).
 


### PR DESCRIPTION
The windows path in the README was incorrect, and could cause confusion to newcomers to adding the config to their LMStudio `mcp.json`. 

I've updated the WIndows path to reflect the backslashes that must be escaped for correct use within LMStudio to load the MCP.