### PR TITLE
Replace `axios` with native `fetch` and harden search/extraction fallback paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+TypeScript MCP server for multi-engine web search and webpage content extraction using Bing, Brave, DuckDuckGo, Playwright, and Cheerio.
+
+## Scope
+- Applies to this repo only.
+- Keep changes small, direct, repo-shaped.
+
+## Stack
+- TypeScript
+- Node.js ESM
+- MCP server over stdio
+- Playwright for browser-backed search/extraction
+- Cheerio for HTML parsing
+
+## Key Files
+- `src/index.ts`: MCP server, tool registration, request handling
+- `src/search-engine.ts`: Bing/Brave/DuckDuckGo search flow and result parsing
+- `src/enhanced-content-extractor.ts`: fetch-first page extraction, browser fallback
+- `src/browser-pool.ts`: shared Playwright browser lifecycle
+- `src/fetch-utils.ts`: HTTP fetch wrapper and fetch errors
+- `src/rate-limiter.ts`: concurrency + request throttling
+- `tests/`: ad hoc runtime tests, not a formal test framework
+
+## Commands
+- `npm run build`: compile to `dist/`
+- `npm run lint`: ESLint; warnings exist, errors should not
+- `npm test`: basic search smoke test
+- `node tests/test-all-engines.js`: broader end-to-end search smoke test
+- `node tests/test-bing.js`
+- `node tests/test-brave.js`
+- `node tests/test-duckduckgo.js`
+- `node tests/test-duckduckgo-fetch.js`
+
+## Change Rules
+- Prefer targeted fixes over refactors.
+- Preserve public tool names and current MCP behavior unless asked.
+- For parser bugs, patch the parser/URL cleaner directly; avoid broader rewrites.
+- For extraction failures on third-party sites, prefer clearer failure handling over anti-bot evasion work.
+- Keep env vars real: do not document or expose config that has no runtime effect.
+
+## Verification
+- Run the narrowest relevant check first.
+- For code changes, usually run `npm run build`.
+- Run `npm run lint` if touching TypeScript.
+- Run only the relevant `tests/test-*.js` script when possible.
+- If Playwright/browser behavior differs by environment, state that plainly in the result.
+
+## Notes
+- `dist/` is build output. Edit `src/`, not `dist/`.
+- Search may succeed even when one engine fails; confirm which engine actually served the result.
+- `BROWSER_FALLBACK_THRESHOLD` is per-host in the extractor. Do not assume immediate browser fallback.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A TypeScript MCP (Model Context Protocol) server that provides comprehensive web
 - **Multi-Engine Web Search**: Prioritises Bing > Brave > DuckDuckGo for optimal reliability and performance
 - **Full Page Content Extraction**: Fetches and extracts complete page content from search results
 - **Multiple Search Tools**: Three specialised tools for different use cases
-- **Smart Request Strategy**: Switches between playwright browesrs and fast axios requests to ensure results are returned
+- **Smart Request Strategy**: Uses fast native `fetch` requests first, then falls back to browser-based extraction if bot detection is encountered
 - **Concurrent Processing**: Extracts content from multiple pages simultaneously
 
 ## How It Works
@@ -18,9 +18,9 @@ The server provides three specialised tools for different web search needs:
 When a comprehensive search is requested, the server uses an **optimised search strategy**:
 1. **Browser-based Bing Search** - Primary method using dedicated Chromium instance
 2. **Browser-based Brave Search** - Secondary option using dedicated Firefox instance
-3. **Axios DuckDuckGo Search** - Final fallback using traditional HTTP
+3. **Fetch DuckDuckGo Search** - Final fallback using traditional HTTP
 4. **Dedicated browser isolation**: Each search engine gets its own browser instance with automatic cleanup
-5. **Content extraction**: Tries axios first, then falls back to browser with human behavior simulation
+5. **Content extraction**: Tries `fetch` first, then falls back to browser with human behavior simulation
 6. **Concurrent processing**: Extracts content from multiple pages simultaneously with timeout protection
 7. **HTTP/2 error recovery**: Automatically falls back to HTTP/1.1 when protocol errors occur
 
@@ -139,7 +139,7 @@ The server supports several environment variables for configuration:
 - **`DEFAULT_TIMEOUT`**: Default timeout for requests in milliseconds (default: 6000)
 - **`MAX_BROWSERS`**: Maximum number of browser instances to maintain (default: 3)
 - **`BROWSER_TYPES`**: Comma-separated list of browser types to use (default: 'chromium,firefox', options: chromium, firefox, webkit)
-- **`BROWSER_FALLBACK_THRESHOLD`**: Number of axios failures before using browser fallback (default: 3)
+- **`BROWSER_FALLBACK_THRESHOLD`**: Number of fetch failures before using browser fallback (default: 3)
 
 ### Search Quality and Engine Selection
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The server supports several environment variables for configuration:
 - **`DEFAULT_TIMEOUT`**: Default timeout for requests in milliseconds (default: 6000)
 - **`MAX_BROWSERS`**: Maximum number of browser instances to maintain (default: 3)
 - **`BROWSER_TYPES`**: Comma-separated list of browser types to use (default: 'chromium,firefox', options: chromium, firefox, webkit)
-- **`BROWSER_FALLBACK_THRESHOLD`**: Number of fetch failures before using browser fallback (default: 3)
+- **`BROWSER_FALLBACK_THRESHOLD`**: Per-host number of qualifying fetch failures before using browser fallback (default: 3)
 
 ### Search Quality and Engine Selection
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A TypeScript MCP (Model Context Protocol) server that provides comprehensive web search capabilities using direct connections (no API keys required) with multiple tools for different use cases.
 
+## Fork Changes
+
+This fork includes a few targeted changes:
+
+- Replaced `axios` with native `fetch`
+- Logs are routed away from stdout so `StdioServerTransport` does not corrupt MCP responses
+- `full-web-search` now respects the `maxContentLength` argument
+- Timed-out extractions now cancel underlying work and clean up browser contexts properly
+- Browser fallback is now gated per host via `BROWSER_FALLBACK_THRESHOLD` instead of jumping to Playwright immediately
+- Browser engines that fail to launch are disabled for the rest of the process so search can fall back cleanly
+- Bing redirect URLs are decoded more reliably before content extraction
+- Rate limiting now runs inside the concurrency gate, avoiding races under parallel load
+- Search result URL validation is stricter to avoid junk/internal links
+- Added `npm test` plus a fetch-based DuckDuckGo test path
+
 ## Features
 
 - **Multi-Engine Web Search**: Prioritises Bing > Brave > DuckDuckGo for optimal reliability and performance

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,7 @@ export default [
         TextEncoder: 'readonly',
         TextDecoder: 'readonly',
         AbortController: 'readonly',
+        AbortSignal: 'readonly',
         Blob: 'readonly',
         Event: 'readonly',
         EventTarget: 'readonly',
@@ -52,6 +53,7 @@ export default [
         document: 'readonly',
         Response: 'readonly',
         Request: 'readonly',
+        PermissionStatus: 'readonly',
         XMLHttpRequest: 'readonly',
         // Add more as needed
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "web-search-mcp-server",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-search-mcp-server",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.0",
-        "axios": "^1.6.8",
         "cheerio": "^1.0.0-rc.12",
         "p-limit": "^6.2.0",
         "p-retry": "^6.2.1",
-        "playwright": "^1.48.0"
+        "playwright": "^1.48.0",
+        "zod": "^3.22.0"
       },
       "bin": {
         "web-search-mcp": "dist/index.js"
@@ -1121,23 +1121,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1321,18 +1304,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1457,15 +1428,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -1610,21 +1572,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2132,63 +2079,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2341,21 +2231,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3097,12 +2972,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.0",
-    "axios": "^1.6.8",
     "cheerio": "^1.0.0-rc.12",
     "p-limit": "^6.2.0",
     "p-retry": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node ./dist/index.js",
     "lint": "eslint \"src/**/*.ts\"",
+    "test": "node tests/test-search.js",
     "format": "prettier --write ."
   },
   "keywords": [

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -51,7 +51,6 @@ try {
       'combined-stream',
       'mime-types',
       'mime-db',
-      'axios'
     ],
     sourcemap: true,
     minify: false, // Keep readable for debugging

--- a/src/content-extractor.ts
+++ b/src/content-extractor.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import * as cheerio from 'cheerio';
+import { fetchText, isFetchError } from './fetch-utils.js';
 import { ContentExtractionOptions, SearchResult } from './types.js';
 import { cleanText, getWordCount, getContentPreview, generateTimestamp, isPdfUrl } from './utils.js';
 
@@ -24,7 +24,7 @@ export class ContentExtractor {
     const { url, timeout = this.defaultTimeout, maxContentLength = this.maxContentLength } = options;
     
     try {
-      const response = await axios.get(url, {
+      const response = await fetchText(url, {
         headers: {
           'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
           'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
@@ -44,7 +44,6 @@ export class ContentExtractor {
         },
         timeout,
         maxContentLength,
-        validateStatus: (status: number) => status < 400,
       });
 
       return this.parseContent(response.data);
@@ -52,10 +51,10 @@ export class ContentExtractor {
       console.error(`Content extraction error for ${url}:`, error);
       
       // If it's a 403 error, try with different headers
-      if (axios.isAxiosError(error) && error.response?.status === 403) {
+      if (isFetchError(error) && error.status === 403) {
         console.log(`[ContentExtractor] Trying alternative headers for ${url}`);
         try {
-          const response = await axios.get(url, {
+          const response = await fetchText(url, {
             headers: {
               'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
               'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -69,7 +68,6 @@ export class ContentExtractor {
             },
             timeout,
             maxContentLength,
-            validateStatus: (status: number) => status < 400,
           });
           
           console.log(`[ContentExtractor] Alternative headers worked for ${url}`);
@@ -236,21 +234,21 @@ export class ContentExtractor {
   }
 
   private getSpecificErrorMessage(error: unknown): string {
-    if (axios.isAxiosError(error)) {
+    if (isFetchError(error)) {
       if (error.code === 'ECONNABORTED') {
         return 'Request timeout';
       }
-      if (error.response?.status === 403) {
+      if (error.status === 403) {
         return '403 Forbidden - Access denied';
       }
-      if (error.response?.status === 404) {
+      if (error.status === 404) {
         return '404 Not found';
       }
-      if (error.message.includes('maxContentLength')) {
+      if (error.code === 'MAX_CONTENT_LENGTH_EXCEEDED' || error.message.includes('maxContentLength')) {
         return 'Content too long';
       }
-      if (error.response?.status) {
-        return `HTTP ${error.response.status}: ${error.message}`;
+      if (error.status) {
+        return `HTTP ${error.status}: ${error.message}`;
       }
       return `Network error: ${error.message}`;
     }

--- a/src/enhanced-content-extractor.ts
+++ b/src/enhanced-content-extractor.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio';
-import { Page } from 'playwright';
+import { BrowserContext, Page } from 'playwright';
 import { fetchText, isFetchError } from './fetch-utils.js';
 import { ContentExtractionOptions, SearchResult } from './types.js';
 import { cleanText, getWordCount, getContentPreview, generateTimestamp, isPdfUrl } from './utils.js';
@@ -61,14 +61,15 @@ export class EnhancedContentExtractor {
   }
 
   private async extractWithFetch(options: ContentExtractionOptions): Promise<string> {
-    const { url, timeout = this.defaultTimeout, maxContentLength = this.maxContentLength } = options;
+    const { url, timeout = this.defaultTimeout, maxContentLength = this.maxContentLength, signal } = options;
     
     const response = await fetchText(url, {
       headers: this.getRandomHeaders(),
+      signal,
       timeout,
     });
 
-    let content = this.parseContent(response.data);
+    let content = this.parseContent(response.data, maxContentLength);
     
     // Truncate content if it exceeds the limit (instead of failing the request)
     if (maxContentLength && content.length > maxContentLength) {
@@ -85,12 +86,18 @@ export class EnhancedContentExtractor {
   }
 
   private async extractWithBrowser(options: ContentExtractionOptions): Promise<string> {
-    const { url, timeout = this.defaultTimeout } = options;
+    const { url, timeout = this.defaultTimeout, maxContentLength = this.maxContentLength, signal } = options;
     
     const browser = await this.browserPool.getBrowser();
     const browserType = this.browserPool.getLastUsedBrowserType();
+    let context: BrowserContext | undefined;
+    let abortHandler: (() => void) | undefined;
     
     try {
+      if (signal?.aborted) {
+        throw new Error('Content extraction aborted');
+      }
+
       // Create context options based on browser capabilities
       const baseContextOptions = {
         userAgent: this.getRandomUserAgent(),
@@ -112,7 +119,14 @@ export class EnhancedContentExtractor {
         : { ...baseContextOptions, isMobile: Math.random() > 0.8 };
 
       // Create a new context for each request (isolation)
-      const context = await browser.newContext(contextOptions);
+      context = await browser.newContext(contextOptions);
+
+      if (signal) {
+        abortHandler = () => {
+          void context?.close().catch(() => {});
+        };
+        signal.addEventListener('abort', abortHandler, { once: true });
+      }
 
       // Add stealth scripts to avoid detection
       await context.addInitScript(() => {
@@ -178,7 +192,7 @@ export class EnhancedContentExtractor {
           
           // Create a new context with HTTP/1.1 preference
           await context.close();
-          const http1Context = await browser.newContext({
+          context = await browser.newContext({
             userAgent: this.getRandomUserAgent(),
             viewport: this.getRandomViewport(),
             locale: 'en-US',
@@ -189,7 +203,7 @@ export class EnhancedContentExtractor {
             }
           });
           
-          const http1Page = await http1Context.newPage();
+          const http1Page = await context.newPage();
           
           // Disable HTTP/2 by intercepting requests
           await http1Page.route('**/*', (route) => {
@@ -208,8 +222,7 @@ export class EnhancedContentExtractor {
           
           // Quick content extraction
           const html = await http1Page.content();
-          const content = this.parseContent(html);
-          await http1Context.close();
+          const content = this.parseContent(html, maxContentLength);
           return content;
         } else {
           throw gotoError;
@@ -233,14 +246,23 @@ export class EnhancedContentExtractor {
 
       // Extract content using the same parsing logic as the HTTP fetch path
       const html = await page.content();
-      const content = this.parseContent(html);
+      const content = this.parseContent(html, maxContentLength);
 
-      await context.close();
       return content;
 
     } catch (error) {
+      if (signal?.aborted) {
+        throw new Error('Content extraction aborted');
+      }
       console.error(`[BrowserExtractor] Browser extraction failed for ${url}:`, error);
       throw error;
+    } finally {
+      if (signal && abortHandler) {
+        signal.removeEventListener('abort', abortHandler);
+      }
+      if (context) {
+        await context.close().catch(() => {});
+      }
     }
   }
 
@@ -395,7 +417,7 @@ export class EnhancedContentExtractor {
     return timezones[Math.floor(Math.random() * timezones.length)];
   }
 
-  async extractContentForResults(results: SearchResult[], targetCount: number = results.length): Promise<SearchResult[]> {
+  async extractContentForResults(results: SearchResult[], targetCount: number = results.length, maxContentLength?: number): Promise<SearchResult[]> {
     console.log(`[EnhancedContentExtractor] Processing up to ${results.length} results to get ${targetCount} non-PDF results`);
     
     // Filter out PDF files first
@@ -406,19 +428,22 @@ export class EnhancedContentExtractor {
     
     // Process results concurrently with timeout
     const extractionPromises = resultsToProcess.map(async (result): Promise<SearchResult> => {
+      const controller = new AbortController();
+      let timedOut = false;
+      const timeoutId = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, 8000);
+
       try {
-        // Use a race condition with timeout to prevent hanging
         const extractionPromise = this.extractContent({ 
           url: result.url, 
-          timeout: 6000 // Reduced timeout to 6 seconds per page
+          timeout: 6000, // Reduced timeout to 6 seconds per page
+          maxContentLength,
+          signal: controller.signal,
         });
-        
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Content extraction timeout')), 8000);
-        });
-        
-        const content = await Promise.race([extractionPromise, timeoutPromise]);
-        const cleanedContent = cleanText(content, this.maxContentLength);
+
+        const cleanedContent = await extractionPromise;
         
         console.log(`[EnhancedContentExtractor] Successfully extracted: ${result.url}`);
         return {
@@ -430,6 +455,7 @@ export class EnhancedContentExtractor {
           fetchStatus: 'success' as const,
         };
       } catch (error) {
+        const extractionError = timedOut ? new Error('Content extraction timeout') : error;
         console.log(`[EnhancedContentExtractor] Failed to extract: ${result.url} - ${error instanceof Error ? error.message : 'Unknown error'}`);
         return {
           ...result,
@@ -438,8 +464,10 @@ export class EnhancedContentExtractor {
           wordCount: 0,
           timestamp: generateTimestamp(),
           fetchStatus: 'error' as const,
-          error: this.getSpecificErrorMessage(error),
+          error: this.getSpecificErrorMessage(extractionError),
         };
+      } finally {
+        clearTimeout(timeoutId);
       }
     });
     
@@ -460,7 +488,7 @@ export class EnhancedContentExtractor {
     return enhancedResults;
   }
 
-  private parseContent(html: string): string {
+  private parseContent(html: string, maxContentLength: number = this.maxContentLength): string {
     const $ = cheerio.load(html);
     
     // Remove all script, style, and other non-content elements
@@ -531,7 +559,9 @@ export class EnhancedContentExtractor {
     // Clean up the text
     const cleanedContent = this.cleanTextContent(mainContent);
     
-    return cleanText(cleanedContent, this.maxContentLength);
+    return maxContentLength === 0
+      ? cleanText(cleanedContent, cleanedContent.length)
+      : cleanText(cleanedContent, maxContentLength);
   }
   
   private cleanTextContent(text: string): string {

--- a/src/enhanced-content-extractor.ts
+++ b/src/enhanced-content-extractor.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { Page } from 'playwright';
+import { fetchText, isFetchError } from './fetch-utils.js';
 import { ContentExtractionOptions, SearchResult } from './types.js';
 import { cleanText, getWordCount, getContentPreview, generateTimestamp, isPdfUrl } from './utils.js';
 import { BrowserPool } from './browser-pool.js';
@@ -37,11 +37,11 @@ export class EnhancedContentExtractor {
     
     // First, try with regular HTTP client (faster)
     try {
-      const content = await this.extractWithAxios(options);
-      console.log(`[EnhancedContentExtractor] Successfully extracted with axios: ${content.length} chars`);
+      const content = await this.extractWithFetch(options);
+      console.log(`[EnhancedContentExtractor] Successfully extracted with fetch: ${content.length} chars`);
       return content;
     } catch (error) {
-      console.log(`[EnhancedContentExtractor] Axios failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.log(`[EnhancedContentExtractor] Fetch failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
       
       // Check if this looks like a case where browser would help
       if (this.shouldUseBrowser(error, url)) {
@@ -52,7 +52,7 @@ export class EnhancedContentExtractor {
           return content;
         } catch (browserError) {
           console.error(`[EnhancedContentExtractor] Browser extraction also failed:`, browserError);
-          throw new Error(`Both axios and browser extraction failed for ${url}`);
+          throw new Error(`Both fetch and browser extraction failed for ${url}`);
         }
       } else {
         throw error;
@@ -60,19 +60,17 @@ export class EnhancedContentExtractor {
     }
   }
 
-  private async extractWithAxios(options: ContentExtractionOptions): Promise<string> {
+  private async extractWithFetch(options: ContentExtractionOptions): Promise<string> {
     const { url, timeout = this.defaultTimeout, maxContentLength = this.maxContentLength } = options;
     
-    const response = await axios.get(url, {
+    const response = await fetchText(url, {
       headers: this.getRandomHeaders(),
       timeout,
-      // Remove maxContentLength from axios config - handle truncation manually
-      validateStatus: (status: number) => status < 400,
     });
 
     let content = this.parseContent(response.data);
     
-    // Truncate content if it exceeds the limit (instead of axios throwing an error)
+    // Truncate content if it exceeds the limit (instead of failing the request)
     if (maxContentLength && content.length > maxContentLength) {
       console.log(`[EnhancedContentExtractor] Content truncated from ${content.length} to ${maxContentLength} characters for ${url}`);
       content = content.substring(0, maxContentLength);
@@ -233,7 +231,7 @@ export class EnhancedContentExtractor {
         console.log(`[BrowserExtractor] No main content selector found, proceeding anyway`);
       }
 
-      // Extract content using the same logic as axios version
+      // Extract content using the same parsing logic as the HTTP fetch path
       const html = await page.content();
       const content = this.parseContent(html);
 
@@ -276,24 +274,24 @@ export class EnhancedContentExtractor {
   }
 
   private shouldUseBrowser(error: any, url: string): boolean {
-    // Conditions where browser is likely to succeed where axios failed
+    // Conditions where browser is likely to succeed where fetch failed
     const indicators = [
       // HTTP status codes that suggest bot detection
-      error.response?.status === 403,
-      error.response?.status === 429,
-      error.response?.status === 503,
+      error?.status === 403,
+      error?.status === 429,
+      error?.status === 503,
       
       // Error messages suggesting JS requirement
-      error.message?.includes('timeout'),
-      error.message?.includes('Access denied'),
-      error.message?.includes('Forbidden'),
-      error.message?.includes('Low quality content detected'),
+      error?.message?.includes('timeout'),
+      error?.message?.includes('Access denied'),
+      error?.message?.includes('Forbidden'),
+      error?.message?.includes('Low quality content detected'),
       
       // Response content suggesting bot detection
-      error.response?.data?.includes('Please enable JavaScript'),
-      error.response?.data?.includes('captcha'),
-      error.response?.data?.includes('unusual traffic'),
-      error.response?.data?.includes('robot'),
+      error?.body?.includes('Please enable JavaScript'),
+      error?.body?.includes('captcha'),
+      error?.body?.includes('unusual traffic'),
+      error?.body?.includes('robot'),
       
       // Sites known to be JS-heavy
       url.includes('twitter.com'),
@@ -562,21 +560,21 @@ export class EnhancedContentExtractor {
   }
 
   private getSpecificErrorMessage(error: unknown): string {
-    if (axios.isAxiosError(error)) {
+    if (isFetchError(error)) {
       if (error.code === 'ECONNABORTED') {
         return 'Request timeout';
       }
-      if (error.response?.status === 403) {
+      if (error.status === 403) {
         return '403 Forbidden - Access denied';
       }
-      if (error.response?.status === 404) {
+      if (error.status === 404) {
         return '404 Not found';
       }
-      if (error.message.includes('maxContentLength')) {
+      if (error.code === 'MAX_CONTENT_LENGTH_EXCEEDED' || error.message.includes('maxContentLength')) {
         return 'Content too long';
       }
-      if (error.response?.status) {
-        return `HTTP ${error.response.status}: ${error.message}`;
+      if (error.status) {
+        return `HTTP ${error.status}: ${error.message}`;
       }
       return `Network error: ${error.message}`;
     }

--- a/src/enhanced-content-extractor.ts
+++ b/src/enhanced-content-extractor.ts
@@ -8,8 +8,9 @@ import { BrowserPool } from './browser-pool.js';
 export class EnhancedContentExtractor {
   private readonly defaultTimeout: number;
   private readonly maxContentLength: number;
+  private readonly browserFallbackThreshold: number;
   private browserPool: BrowserPool;
-  private fallbackThreshold: number;
+  private browserFallbackFailuresByHost: Map<string, number>;
 
   constructor() {
     this.defaultTimeout = parseInt(process.env.DEFAULT_TIMEOUT || '6000', 10);
@@ -23,11 +24,14 @@ export class EnhancedContentExtractor {
       console.warn(`[EnhancedContentExtractor] Invalid MAX_CONTENT_LENGTH value: ${envMaxLength}, using default 500000`);
       this.maxContentLength = 500000;
     }
+
+    const parsedBrowserFallbackThreshold = parseInt(process.env.BROWSER_FALLBACK_THRESHOLD || '3', 10);
+    this.browserFallbackThreshold = parsedBrowserFallbackThreshold > 0 ? parsedBrowserFallbackThreshold : 3;
     
     this.browserPool = new BrowserPool();
-    this.fallbackThreshold = parseInt(process.env.BROWSER_FALLBACK_THRESHOLD || '3', 10);
+    this.browserFallbackFailuresByHost = new Map();
     
-    console.log(`[EnhancedContentExtractor] Configuration: timeout=${this.defaultTimeout}, maxContentLength=${this.maxContentLength}, fallbackThreshold=${this.fallbackThreshold}`);
+    console.log(`[EnhancedContentExtractor] Configuration: timeout=${this.defaultTimeout}, maxContentLength=${this.maxContentLength}, browserFallbackThreshold=${this.browserFallbackThreshold}`);
   }
 
   async extractContent(options: ContentExtractionOptions): Promise<string> {
@@ -38,6 +42,7 @@ export class EnhancedContentExtractor {
     // First, try with regular HTTP client (faster)
     try {
       const content = await this.extractWithFetch(options);
+      this.resetBrowserFallbackFailures(url);
       console.log(`[EnhancedContentExtractor] Successfully extracted with fetch: ${content.length} chars`);
       return content;
     } catch (error) {
@@ -45,6 +50,12 @@ export class EnhancedContentExtractor {
       
       // Check if this looks like a case where browser would help
       if (this.shouldUseBrowser(error, url)) {
+        const failureCount = this.recordBrowserFallbackFailure(url);
+        if (failureCount < this.browserFallbackThreshold) {
+          console.log(`[EnhancedContentExtractor] Browser fallback threshold not reached for ${this.getBrowserFallbackHost(url)} (${failureCount}/${this.browserFallbackThreshold})`);
+          throw error;
+        }
+
         console.log(`[EnhancedContentExtractor] Falling back to headless browser for: ${url}`);
         try {
           const content = await this.extractWithBrowser(options);
@@ -325,6 +336,25 @@ export class EnhancedContentExtractor {
     ];
 
     return indicators.some(indicator => indicator === true);
+  }
+
+  private getBrowserFallbackHost(url: string): string {
+    try {
+      return new URL(url).hostname.toLowerCase();
+    } catch {
+      return url;
+    }
+  }
+
+  private recordBrowserFallbackFailure(url: string): number {
+    const host = this.getBrowserFallbackHost(url);
+    const failureCount = (this.browserFallbackFailuresByHost.get(host) || 0) + 1;
+    this.browserFallbackFailuresByHost.set(host, failureCount);
+    return failureCount;
+  }
+
+  private resetBrowserFallbackFailures(url: string): void {
+    this.browserFallbackFailuresByHost.delete(this.getBrowserFallbackHost(url));
   }
 
   private isLowQualityContent(content: string): boolean {

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -1,0 +1,93 @@
+type FetchTextOptions = {
+  headers?: Record<string, string>;
+  maxContentLength?: number;
+  params?: Record<string, string>;
+  timeout: number;
+};
+
+type FetchErrorOptions = {
+  body?: string;
+  cause?: unknown;
+  code?: string;
+  status?: number;
+  statusText?: string;
+};
+
+export class FetchError extends Error {
+  body?: string;
+  code?: string;
+  status?: number;
+  statusText?: string;
+
+  constructor(message: string, options: FetchErrorOptions = {}) {
+    super(message, options.cause ? { cause: options.cause } : undefined);
+    this.name = 'FetchError';
+    this.body = options.body;
+    this.code = options.code;
+    this.status = options.status;
+    this.statusText = options.statusText;
+  }
+}
+
+export function isFetchError(error: unknown): error is FetchError {
+  return error instanceof FetchError;
+}
+
+export async function fetchText(url: string, options: FetchTextOptions): Promise<{ data: string; status: number; statusText: string }> {
+  const targetUrl = new URL(url);
+
+  if (options.params) {
+    for (const [key, value] of Object.entries(options.params)) {
+      targetUrl.searchParams.set(key, value);
+    }
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options.timeout);
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: options.headers,
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    const data = await response.text();
+
+    if (!response.ok) {
+      throw new FetchError(`Request failed with status ${response.status}`, {
+        body: data,
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+
+    if (options.maxContentLength && data.length > options.maxContentLength) {
+      throw new FetchError('maxContentLength exceeded', {
+        code: 'MAX_CONTENT_LENGTH_EXCEEDED',
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+
+    return {
+      data,
+      status: response.status,
+      statusText: response.statusText,
+    };
+  } catch (error) {
+    if (error instanceof FetchError) {
+      throw error;
+    }
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new FetchError('Request timeout', {
+        cause: error,
+        code: 'ECONNABORTED',
+      });
+    }
+    throw new FetchError(error instanceof Error ? error.message : 'Network error', {
+      cause: error,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -2,6 +2,7 @@ type FetchTextOptions = {
   headers?: Record<string, string>;
   maxContentLength?: number;
   params?: Record<string, string>;
+  signal?: AbortSignal;
   timeout: number;
 };
 
@@ -43,7 +44,20 @@ export async function fetchText(url: string, options: FetchTextOptions): Promise
   }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), options.timeout);
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, options.timeout);
+  const abortHandler = () => controller.abort(options.signal?.reason);
+
+  if (options.signal) {
+    if (options.signal.aborted) {
+      controller.abort(options.signal.reason);
+    } else {
+      options.signal.addEventListener('abort', abortHandler, { once: true });
+    }
+  }
 
   try {
     const response = await fetch(targetUrl, {
@@ -79,6 +93,18 @@ export async function fetchText(url: string, options: FetchTextOptions): Promise
       throw error;
     }
     if (error instanceof Error && error.name === 'AbortError') {
+      if (timedOut) {
+        throw new FetchError('Request timeout', {
+          cause: error,
+          code: 'ECONNABORTED',
+        });
+      }
+      if (options.signal?.aborted) {
+        throw new FetchError('Request aborted', {
+          cause: error,
+          code: 'ECANCELED',
+        });
+      }
       throw new FetchError('Request timeout', {
         cause: error,
         code: 'ECONNABORTED',
@@ -89,5 +115,6 @@ export async function fetchText(url: string, options: FetchTextOptions): Promise
     });
   } finally {
     clearTimeout(timeoutId);
+    options.signal?.removeEventListener('abort', abortHandler);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,8 +275,7 @@ class WebSearchMCPServer {
             if (typeof maxLengthValue !== 'number' || isNaN(maxLengthValue) || maxLengthValue < 0) {
               throw new Error('Invalid maxContentLength: must be a non-negative number');
             }
-            // If maxContentLength is 0, treat it as "no limit" (undefined)
-            maxContentLength = maxLengthValue === 0 ? undefined : maxLengthValue;
+            maxContentLength = maxLengthValue;
           }
 
           console.log(`[MCP] Starting single page content extraction for: ${obj.url}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-console.log('Web Search MCP Server starting...');
+// MCP stdio uses stdout for protocol frames; route logs to stderr.
+console.log = console.error.bind(console);
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -354,16 +355,26 @@ class WebSearchMCPServer {
       }
     }
 
+    let maxContentLength: number | undefined;
+    if (obj.maxContentLength !== undefined) {
+      const maxLengthValue = typeof obj.maxContentLength === 'string' ? parseInt(obj.maxContentLength, 10) : obj.maxContentLength;
+      if (typeof maxLengthValue !== 'number' || isNaN(maxLengthValue) || maxLengthValue < 0) {
+        throw new Error('Invalid maxContentLength: must be a non-negative number');
+      }
+      maxContentLength = maxLengthValue;
+    }
+
     return {
       query: obj.query,
       limit,
       includeContent,
+      maxContentLength,
     };
   }
 
   private async handleWebSearch(input: WebSearchToolInput): Promise<WebSearchToolOutput> {
     const startTime = Date.now();
-    const { query, limit = 5, includeContent = true } = input;
+    const { query, limit = 5, includeContent = true, maxContentLength } = input;
     
     console.error(`[web-search-mcp] DEBUG: handleWebSearch called with limit=${limit}, includeContent=${includeContent}`);
 
@@ -388,7 +399,7 @@ class WebSearchMCPServer {
 
       // Extract content from each result if requested, with target count
       const enhancedResults = includeContent 
-        ? await this.contentExtractor.extractContentForResults(searchResults, limit)
+        ? await this.contentExtractor.extractContentForResults(searchResults, limit, maxContentLength)
         : searchResults.slice(0, limit); // If not extracting content, just take the first 'limit' results
       
       // Log extraction summary with failure reasons and generate combined status

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -13,26 +13,21 @@ export class RateLimiter {
   }
 
   async execute<T>(fn: () => Promise<T>): Promise<T> {
-    // Check if we need to reset the counter
-    const now = Date.now();
-    if (now - this.lastResetTime >= this.resetIntervalMs) {
-      this.requestCount = 0;
-      this.lastResetTime = now;
-    }
+    return this.limit(async () => {
+      const now = Date.now();
+      if (now - this.lastResetTime >= this.resetIntervalMs) {
+        this.requestCount = 0;
+        this.lastResetTime = now;
+      }
 
-    // Check rate limit
-    if (this.requestCount >= this.maxRequestsPerMinute) {
-      const waitTime = this.resetIntervalMs - (now - this.lastResetTime);
-      throw new Error(`Rate limit exceeded. Please wait ${Math.ceil(waitTime / 1000)} seconds.`);
-    }
+      if (this.requestCount >= this.maxRequestsPerMinute) {
+        const waitTime = this.resetIntervalMs - (now - this.lastResetTime);
+        throw new Error(`Rate limit exceeded. Please wait ${Math.ceil(waitTime / 1000)} seconds.`);
+      }
 
-    // Execute with concurrency limit
-    const result = await this.limit(async () => {
       this.requestCount++;
-      return await fn();
+      return fn();
     });
-
-    return result;
   }
 
   getStatus(): { requestCount: number; maxRequests: number; resetTime: number } {

--- a/src/search-engine.ts
+++ b/src/search-engine.ts
@@ -8,10 +8,12 @@ import { BrowserPool } from './browser-pool.js';
 export class SearchEngine {
   private readonly rateLimiter: RateLimiter;
   private browserPool: BrowserPool;
+  private unavailableBrowserEngines: Set<string>;
 
   constructor() {
     this.rateLimiter = new RateLimiter(10); // 10 requests per minute
     this.browserPool = new BrowserPool();
+    this.unavailableBrowserEngines = new Set();
   }
 
   async search(options: SearchOptions): Promise<SearchResultWithMetadata> {
@@ -37,7 +39,7 @@ export class SearchEngine {
           { method: this.tryBrowserBingSearch.bind(this), name: 'Browser Bing' },
           { method: this.tryBrowserBraveSearch.bind(this), name: 'Browser Brave' },
           { method: this.tryDuckDuckGoSearch.bind(this), name: 'Fetch DuckDuckGo' }
-        ];
+        ].filter(approach => !this.unavailableBrowserEngines.has(approach.name));
         
         let bestResults: SearchResult[] = [];
         let bestEngine = 'None';
@@ -778,7 +780,6 @@ export class SearchEngine {
   }
 
   private parseBingResults(html: string, maxResults: number): SearchResult[] {
-    const debugBing = process.env.DEBUG_BING_SEARCH === 'true';
     console.error(`[SearchEngine] BING: Parsing HTML with length: ${html.length}`);
     
     const $ = cheerio.load(html);
@@ -980,16 +981,26 @@ export class SearchEngine {
   }
 
   private cleanBingUrl(url: string): string {
-    // Bing URLs are usually direct, but check for any redirect patterns
     if (url.startsWith('//')) {
       return 'https:' + url;
     }
-    
-    // If it's already a full URL, return as-is
-    if (url.startsWith('http://') || url.startsWith('https://')) {
+
+    try {
+      const parsed = new URL(url);
+
+      if (parsed.hostname.endsWith('bing.com') && parsed.pathname.startsWith('/ck/a')) {
+        const encodedTarget = parsed.searchParams.get('u');
+        if (encodedTarget?.startsWith('a1')) {
+          const decodedTarget = Buffer.from(encodedTarget.substring(2), 'base64').toString('utf8');
+          if (decodedTarget.startsWith('http://') || decodedTarget.startsWith('https://')) {
+            return decodedTarget;
+          }
+        }
+      }
+    } catch {
       return url;
     }
-    
+
     return url;
   }
 
@@ -1134,6 +1145,11 @@ export class SearchEngine {
   private async handleBrowserError(error: any, engineName: string, attemptNumber: number = 1): Promise<void> {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     console.error(`[SearchEngine] ${engineName} browser error (attempt ${attemptNumber}): ${errorMessage}`);
+
+    if ((engineName === 'Browser Bing' || engineName === 'Browser Brave') && this.isBrowserLaunchError(errorMessage)) {
+      this.unavailableBrowserEngines.add(engineName);
+      console.log(`[SearchEngine] Disabling ${engineName} for this process after launch failure`);
+    }
     
     // Check for specific browser-related errors
     if (errorMessage.includes('Target page, context or browser has been closed') ||
@@ -1150,6 +1166,12 @@ export class SearchEngine {
         console.error(`[SearchEngine] Failed to refresh browser pool: ${refreshError instanceof Error ? refreshError.message : 'Unknown error'}`);
       }
     }
+  }
+
+  private isBrowserLaunchError(errorMessage: string): boolean {
+    return errorMessage.includes('browserType.launch') ||
+      errorMessage.includes('Executable doesn\'t exist') ||
+      errorMessage.includes('Failed to launch');
   }
 
   async closeAll(): Promise<void> {

--- a/src/search-engine.ts
+++ b/src/search-engine.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import * as cheerio from 'cheerio';
+import { fetchText, isFetchError } from './fetch-utils.js';
 import { SearchOptions, SearchResult, SearchResultWithMetadata } from './types.js';
 import { generateTimestamp, sanitizeQuery } from './utils.js';
 import { RateLimiter } from './rate-limiter.js';
@@ -36,7 +36,7 @@ export class SearchEngine {
         const approaches = [
           { method: this.tryBrowserBingSearch.bind(this), name: 'Browser Bing' },
           { method: this.tryBrowserBraveSearch.bind(this), name: 'Browser Brave' },
-          { method: this.tryDuckDuckGoSearch.bind(this), name: 'Axios DuckDuckGo' }
+          { method: this.tryDuckDuckGoSearch.bind(this), name: 'Fetch DuckDuckGo' }
         ];
         
         let bestResults: SearchResult[] = [];
@@ -103,11 +103,11 @@ export class SearchEngine {
       });
     } catch (error) {
       console.error('[SearchEngine] Search error:', error);
-      if (axios.isAxiosError(error)) {
-        console.error('[SearchEngine] Axios error details:', {
-          status: error.response?.status,
-          statusText: error.response?.statusText,
-          data: error.response?.data?.substring(0, 500),
+      if (isFetchError(error)) {
+        console.error('[SearchEngine] Fetch error details:', {
+          status: error.status,
+          statusText: error.statusText,
+          data: error.body?.substring(0, 500),
         });
       }
       throw new Error(`Failed to perform search: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -503,7 +503,7 @@ export class SearchEngine {
     console.log(`[SearchEngine] Trying DuckDuckGo as fallback...`);
     
     try {
-      const response = await axios.get('https://html.duckduckgo.com/html/', {
+      const response = await fetchText('https://html.duckduckgo.com/html/', {
         params: {
           q: query,
         },
@@ -517,7 +517,6 @@ export class SearchEngine {
           'Upgrade-Insecure-Requests': '1',
         },
         timeout,
-        validateStatus: (status: number) => status < 400,
       });
 
       console.log(`[SearchEngine] DuckDuckGo got response with status: ${response.status}`);

--- a/src/search-engine.ts
+++ b/src/search-engine.ts
@@ -931,15 +931,16 @@ export class SearchEngine {
   }
 
   private isValidSearchUrl(url: string): boolean {
-    // Google search results URLs can be in various formats
-    return url.startsWith('/url?') || 
-           url.startsWith('http://') || 
-           url.startsWith('https://') ||
-           url.startsWith('//') ||
-           url.startsWith('/search?') ||
-           url.startsWith('/') ||
-           url.includes('google.com') ||
-           url.length > 10; // Accept any reasonably long URL
+    if (url.startsWith('/url?') || url.startsWith('//')) {
+      return true;
+    }
+
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
   }
 
   private cleanGoogleUrl(url: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface ContentExtractionOptions {
   url: string;
   timeout?: number;
   maxContentLength?: number;
+  signal?: AbortSignal;
 }
 
 export interface WebSearchToolInput {

--- a/tests/test-duckduckgo-fetch.js
+++ b/tests/test-duckduckgo-fetch.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+// Test DuckDuckGo search independently using the same fetch-based path as production
+import * as cheerio from 'cheerio';
+
+async function testDuckDuckGoFetch() {
+  console.log('=== TESTING DUCKDUCKGO FETCH SEARCH ===');
+
+  try {
+    const query = 'javascript tutorial';
+    const searchUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+    console.log(`Fetching: ${searchUrl}`);
+
+    const startTime = Date.now();
+    const response = await fetch(searchUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+      },
+    });
+    const html = await response.text();
+    const loadTime = Date.now() - startTime;
+
+    console.log(`✓ Response status: ${response.status}`);
+    console.log(`✓ Page loaded successfully in ${loadTime}ms`);
+    console.log(`✓ HTML length: ${html.length} characters`);
+
+    if (!response.ok || html.includes('error-lite') || html.length < 1000) {
+      console.log('❌ Error page or bot detection detected');
+      console.log('Sample HTML:', html.substring(0, 500));
+      return false;
+    }
+
+    const $ = cheerio.load(html);
+    const resultElements = $('.result');
+    console.log(`✓ Found ${resultElements.length} result elements`);
+
+    if (resultElements.length === 0) {
+      console.log('❌ No results found');
+      console.log('Sample HTML:', html.substring(0, 1000));
+      return false;
+    }
+
+    console.log('\n--- SAMPLE RESULTS ---');
+    resultElements.slice(0, 3).each((index, element) => {
+      const titleElement = $(element).find('.result__title a').first();
+      const snippetElement = $(element).find('.result__snippet').first();
+
+      const title = titleElement.text().trim() || 'No title';
+      const url = titleElement.attr('href') || 'No URL';
+      const snippet = snippetElement.text().trim() || 'No snippet';
+
+      console.log(`${index + 1}. ${title}`);
+      console.log(`   URL: ${url}`);
+      console.log(`   Snippet: ${snippet.substring(0, 100)}...`);
+      console.log('');
+    });
+
+    console.log('✅ DUCKDUCKGO FETCH SEARCH: SUCCESS');
+    return true;
+  } catch (error) {
+    console.log(`❌ DUCKDUCKGO FETCH SEARCH FAILED: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}
+
+testDuckDuckGoFetch().then(success => {
+  console.log(`\nDUCKDUCKGO FETCH RESULT: ${success ? 'WORKING ✅' : 'FAILED ❌'}`);
+  process.exit(success ? 0 : 1);
+});

--- a/tests/test-duckduckgo.js
+++ b/tests/test-duckduckgo.js
@@ -62,13 +62,11 @@ async function testDuckDuckGo() {
         ];
         
         let resultElements = [];
-        let workingSelector = '';
         
         for (const selector of resultSelectors) {
           resultElements = await page.$$(selector);
           console.log(`✓ Found ${resultElements.length} elements with selector: ${selector}`);
           if (resultElements.length > 0) {
-            workingSelector = selector;
             break;
           }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

This PR replaces `axios` with native `fetch` and tightens a few reliability issues in the search and content-extraction flow.

## Changes

- replace `axios` usage with native `fetch`
- keep MCP stdout clean by routing logs away from the protocol channel
- make `full-web-search` honor `maxContentLength`
- cancel timed-out extractions instead of letting underlying work continue
- ensure browser contexts are cleaned up on extraction failures
- make browser fallback threshold-based per host via `BROWSER_FALLBACK_THRESHOLD`
- disable browser engines for the rest of the process after launch failures so fallback can continue cleanly
- decode Bing redirect URLs more reliably before extraction
- tighten search-result URL validation to avoid junk/internal links
- fix rate-limiter accounting under concurrent load
- add `npm test` and a fetch-based DuckDuckGo test path

## Why

- remove an unnecessary HTTP dependency
- improve MCP transport safety
- reduce leaked browser work under failure/timeout conditions
- make fallback behavior more predictable
- reduce wasted extraction attempts on bad URLs
- improve resilience when Playwright/browser binaries are unavailable

## Testing

- `npm run build`
- `npm test`